### PR TITLE
CRITICAL bugfix jspsych-visual-circle-search

### DIFF
--- a/plugins/jspsych-visual-search-circle.js
+++ b/plugins/jspsych-visual-search-circle.js
@@ -76,7 +76,7 @@
             }
 
             // get target to draw on
-            display_element.appent($('<svg id="jspsych-visual-search-circle-svg" width='+paper_size+' height='+paper_size+'></svg>'))
+            display_element.append($('<svg id="jspsych-visual-search-circle-svg" width='+paper_size+' height='+paper_size+'></svg>'))
             var paper = Snap('#jspsych-visual-search-circle-svg');
 
             show_fixation();


### PR DESCRIPTION
line 79: "display_element.appent" wasn't working, spelling error, makes whole plugin unrunnable