### PR TITLE
allow timing_max_search = 0

### DIFF
--- a/plugins/jspsych-visual-search-circle.js
+++ b/plugins/jspsych-visual-search-circle.js
@@ -131,7 +131,25 @@
 
                 key_listener = jsPsych.pluginAPI.getKeyboardResponse(after_response, valid_keys, 'date',false);
 
-                if (trial.timing_max_search > 0) {
++              if (trial.timing_max_search > -1) {
+                
+                	if(trial.timing_max_search == 0){
+                		if (!trial_over) {
+
+                            jsPsych.pluginAPI.cancelKeyboardResponse(key_listener);
+
+                            trial_over = true;
+
+                            var rt = -1;
+                            var correct = 0;
+                            var key_press = -1;
+
+                            clear_display();
+
+                            end_trial(rt, correct, key_press);
+                        }
+                	}
+                
                     setTimeout(function() {
 
                         if (!trial_over) {


### PR DESCRIPTION
I added the possibility that the timing_max_search equals 0 so that the search display is not shown at all (circumventing setTimeout)

This might be very specifically handy for my purpose, because I can use the same plugin to show my probe at the fixation stimulus place before the actual search display. In any case, this change does not hurt and just allows timing_max_search = 0 to work