### PR TITLE
Allow overlap between response groups

### DIFF
--- a/plugins/jspsych-multi-stim-multi-response.js
+++ b/plugins/jspsych-multi-stim-multi-response.js
@@ -114,6 +114,11 @@
 
         var whichResponse;
         for (var i = 0; i < trial.choices.length; i++) {
+        	
+          // allow overlap between response groups
+          if (validResponses[i]) {
+            continue;
+          }
 
           for (var j = 0; j < trial.choices[i].length; j++) {
             keycode = (typeof trial.choices[i][j] == 'string') ? jsPsych.pluginAPI.convertKeyCharacterToKeyCode(trial.choices[i][j]) : trial.choices[i][j];


### PR DESCRIPTION
This modification should eliminate the following stipulation in the `choices` parameter for the `multi-stim-multi-response` plugin:

> The response keys may not overlap between response groups.

I've tested this with the `jspsych-multi-stim-multi-response.html` example, and it still functions as expected.