### PR TITLE
Correct behaviour of timing_response parameter in plugin multi-stim-multi-response

### DIFF
--- a/plugins/jspsych-categorize.js
+++ b/plugins/jspsych-categorize.js
@@ -31,7 +31,7 @@
 				trials[i].timeout_message = params.timeout_message || "<p>Please respond faster.</p>";
 				// timing params
 				trials[i].timing_stim = params.timing_stim || -1; // default is to show image until response
-				trials[i].timing_response = params.timing_response || -1; // default is no max response time
+				trials[i].timing_response = (typeof params.timing_response === 'undefined') ? -1 : params.timing_response; // if -1, then wait for response forever
 				trials[i].timing_feedback_duration = params.timing_feedback_duration || 2000;
 			}
 			return trials;
@@ -115,7 +115,7 @@
 				allow_held_key: false
       });
 
-			if(trial.timing_response > 0) {
+			if(trial.timing_response > -1) {
 				setTimeoutHandlers.push(setTimeout(function(){
 					after_response({key: -1, rt: -1});
 				}, trial.timing_response));

--- a/plugins/jspsych-multi-stim-multi-response.js
+++ b/plugins/jspsych-multi-stim-multi-response.js
@@ -32,7 +32,7 @@
           default_timing_array.push(1000);
         }
         trials[i].timing_stim = params.timing_stim || default_timing_array;
-        trials[i].timing_response = params.timing_response || -1; // if -1, then wait for response forever
+        trials[i].timing_response = (typeof params.timing_response === 'undefined') ? -1 : params.timing_response; // if -1, then wait for response forever
         // optional parameters
         trials[i].is_html = (typeof params.is_html === 'undefined') ? false : params.is_html;
         trials[i].prompt = (typeof params.prompt === 'undefined') ? "" : params.prompt;
@@ -204,7 +204,7 @@
       });
 
       // end trial if time limit is set
-      if (trial.timing_response > 0) {
+      if (trial.timing_response > -1) {
         var t2 = setTimeout(function() {
           end_trial();
         }, trial.timing_response);

--- a/plugins/jspsych-single-audio.js
+++ b/plugins/jspsych-single-audio.js
@@ -33,7 +33,7 @@
 				trials[i].response_ends_trial = (typeof params.response_ends_trial === 'undefined') ? true : params.response_ends_trial;
 				// timing parameters
 				// trials[i].timing_stim = params.timing_stim || -1; // if -1, then show indefinitely
-				trials[i].timing_response = params.timing_response || -1; // if -1, then wait for response forever
+				trials[i].timing_response = (typeof params.timing_response === 'undefined') ? -1 : params.timing_response; // if -1, then wait for response forever
 				trials[i].prompt = (typeof params.prompt === 'undefined') ? "" : params.prompt;
 
 			}
@@ -121,7 +121,7 @@
 				audio_context_start_time: startTime
 			});
 			// end trial if time limit is set
-			if (trial.timing_response > 0) {
+			if (trial.timing_response > -1) {
 				var t2 = setTimeout(function() {
 					end_trial();
 				}, trial.timing_response);

--- a/plugins/jspsych-single-stim.js
+++ b/plugins/jspsych-single-stim.js
@@ -25,7 +25,7 @@
 				trials[i].response_ends_trial = (typeof params.response_ends_trial === 'undefined') ? true : params.response_ends_trial;
 				// timing parameters
 				trials[i].timing_stim = params.timing_stim || -1; // if -1, then show indefinitely
-				trials[i].timing_response = params.timing_response || -1; // if -1, then wait for response forever
+				trials[i].timing_response = (typeof params.timing_response === 'undefined') ? -1 : params.timing_response; // if -1, then wait for response forever
 				// optional parameters
 				trials[i].is_html = (typeof params.is_html === 'undefined') ? false : params.is_html;
 				trials[i].prompt = (typeof params.prompt === 'undefined') ? "" : params.prompt;
@@ -133,7 +133,7 @@
 			}
 
 			// end trial if time limit is set
-			if (trial.timing_response > 0) {
+			if (trial.timing_response > -1) {
 				var t2 = setTimeout(function() {
 					end_trial();
 				}, trial.timing_response);


### PR DESCRIPTION
According to documentation timing_reponse = 0 should not result in indefinitely waiting for a response, but end the trial right away.