### PR TITLE
Change behaviour of timing_response in plugin multi-stim-multi-response

### DIFF
--- a/plugins/jspsych-categorize.js
+++ b/plugins/jspsych-categorize.js
@@ -67,6 +67,12 @@
 			if (trial.timing_stim > 0) {
 				setTimeoutHandlers.push(setTimeout(function() {
 					$('#jspsych-categorize-stimulus').css('visibility', 'hidden');
+					// end trial if time limit is set
+					if(trial.timing_response > 0) {
+						setTimeoutHandlers.push(setTimeout(function(){
+							after_response({key: -1, rt: -1});
+						}, trial.timing_response));
+					}
 				}, trial.timing_stim));
 			}
 
@@ -114,12 +120,6 @@
         persist: false,
 				allow_held_key: false
       });
-
-			if(trial.timing_response > 0) {
-				setTimeoutHandlers.push(setTimeout(function(){
-					after_response({key: -1, rt: -1});
-				}, trial.timing_response));
-			}
 
 			function doFeedback(correct, timeout) {
 

--- a/plugins/jspsych-multi-stim-multi-response.js
+++ b/plugins/jspsych-multi-stim-multi-response.js
@@ -182,6 +182,13 @@
               showNextStimulus();
             } else {
               $('#jspsych-multi-stim-multi-response-stimulus').css('visibility', 'hidden');
+	      // end trial if time limit is set
+	      if (trial.timing_response > 0) {
+	        var t2 = setTimeout(function() {
+	          end_trial();
+	        }, trial.timing_response);
+	        setTimeoutHandlers.push(t2);
+	      }
             }
 
           }, trial.timing_stim[whichStimulus]);
@@ -202,20 +209,6 @@
         persist: true,
 				allow_held_key: false
       });
-
-      // calculate total trial time
-      var total_time = 0;
-      for (var i = 0; i < trial.stimuli.length; i++) {
-        total_time += trial.timing_stim[i];
-      }
-      
-      // end trial if time limit is set
-      if (trial.timing_response > 0) {
-        var t2 = setTimeout(function() {
-          end_trial();
-        }, total_time + trial.timing_response);
-        setTimeoutHandlers.push(t2);
-      }
 
     };
 

--- a/plugins/jspsych-multi-stim-multi-response.js
+++ b/plugins/jspsych-multi-stim-multi-response.js
@@ -203,11 +203,17 @@
 				allow_held_key: false
       });
 
+      // calculate total trial time
+      var total_time = 0;
+      for (var i = 0; i < trial.stimuli.length; i++) {
+        total_time += trial.timing_stim[i];
+      }
+      
       // end trial if time limit is set
       if (trial.timing_response > 0) {
         var t2 = setTimeout(function() {
           end_trial();
-        }, trial.timing_response);
+        }, total_time + trial.timing_response);
         setTimeoutHandlers.push(t2);
       }
 

--- a/plugins/jspsych-single-stim.js
+++ b/plugins/jspsych-single-stim.js
@@ -128,16 +128,15 @@
 			if (trial.timing_stim > 0) {
 				var t1 = setTimeout(function() {
 					$('#jspsych-single-stim-stimulus').css('visibility', 'hidden');
+					// end trial if time limit is set
+					if (trial.timing_response > 0) {
+						var t2 = setTimeout(function() {
+							end_trial();
+						}, trial.timing_response);
+						setTimeoutHandlers.push(t2);
+					}
 				}, trial.timing_stim);
 				setTimeoutHandlers.push(t1);
-			}
-
-			// end trial if time limit is set
-			if (trial.timing_response > 0) {
-				var t2 = setTimeout(function() {
-					end_trial();
-				}, trial.timing_response);
-				setTimeoutHandlers.push(t2);
 			}
 
 		};


### PR DESCRIPTION
Old behaviour: timing_response is measured from the start of the trial
New behaviour: timing_response is measured from the end of stimulus presentation

Why?
Ending a trial on a missing response before the end of stimulus presentation is not needed - in this case, one could just change the duration of stimulus presentation to achieve the same effect.
However, trials can consist of a different amount of stimuli - which results in different total trial lengths. Therefore setting a constant post stimulus presentation interval for response collection was not possible, so far.