### PR TITLE
allow customization for fullscreen intro string

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -714,7 +714,11 @@ window.jsPsych = (function() {
       if (keyboardNotAllowed) {
         go();
       } else {
-        DOM_target.innerHTML = '<div style=""><p>The experiment will launch in fullscreen mode when you click the button below.</p><button id="jspsych-fullscreen-btn" class="jspsych-btn">Launch Experiment</button></div>';
+        // backwards compatible for users who enter true as the `fullscreen` value
+        if (fullscreen === true) {
+          fullscreen = `<p>The experiment will launch in fullscreen mode when you click the button below.</p>`;
+        }
+        DOM_target.append(`<div style="">${fullscreen}<button id="jspsych-fullscreen-btn" class="jspsych-btn">Launch Experiment</button></div>`);
         var listener = DOM_target.querySelector('#jspsych-fullscreen-btn').addEventListener('click', function() {
           var element = document.documentElement;
           if (element.requestFullscreen) {


### PR DESCRIPTION
Very simple, interpolation of a string entered as the fullscreen value. backwards compatible for users who enter `true` as the `fullscreen` value

Fixes #368.

I'm not sure if you are accepting PRs, nor if this is how you would want to do it long-term, since you mentioned editing the button as well as moving it into a separate plugin. This is what we're doing though, so I figured I'd show it to you. Feel free to close.